### PR TITLE
fix: update addressable migration for Laravel 12

### DIFF
--- a/database/migrations/2021_12_13_000022_create_addressable_table.php
+++ b/database/migrations/2021_12_13_000022_create_addressable_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->string('state')->nullable();
             $table->string('zip')->nullable();
 
-            $driver = $table->getConnection()->getDriverName();
+            $driver = Schema::getConnection()->getDriverName();
 
             if ($driver === 'pgsql') {
                 $table->string('full_address')->storedAs("street || ', ' || zip || ' ' || city");


### PR DESCRIPTION
Use Schema::getConnection() instead of Blueprint::getConnection() in the addressable migration. Blueprint no longer exposes that method in Laravel 12, which caused `php artisan migrate` to fail.